### PR TITLE
[Add] Soporte a conversión de objetos en función para realizar encoding de campos a utf8

### DIFF
--- a/src/SIUToba/rest/http/vista_json.php
+++ b/src/SIUToba/rest/http/vista_json.php
@@ -94,7 +94,7 @@ class vista_json extends vista_respuesta
 
     protected function utf8_encode_fields($element){
         if (is_string($element)){
-            if (mb_detect_encoding($element[$key], "UTF-8", true) != "UTF-8"){
+            if (mb_detect_encoding($element, "UTF-8", true) != "UTF-8"){
                 $element = utf8_encode($element);
             }
         } elseif (is_array($element)){


### PR DESCRIPTION
Posibilidad de modificar la funcionalidad que transforma los campos de un array a utf8 para que pueda convertir también los campos de un objeto.
Sino se realiza esta conversión el siguiente código de ejemplo va a dar error al momento de utilizar la funcion utf8_encode_fields

```
class example
{
    public $name;
    public function __construct($name)
    {
        $this->name = $name;

    }
}

$object = new example("test");
$array_response = array("data"=>$object);
\SIUToba\rest\rest::response()->get($array_response);
```
